### PR TITLE
Order create, read, update done

### DIFF
--- a/src/Order/OrderController.ts
+++ b/src/Order/OrderController.ts
@@ -1,0 +1,38 @@
+import { Request, Response } from "express";
+import errorHandler from "../Utility/errorHandler.js";
+import OrderService from "./OrderService.js";
+
+
+
+
+export default class OrderController {
+    constructor() {}
+
+    public async getAllOrdersExecutor(request: Request<{}, {}, {}, ReqQuery>, response: Response) {
+        const { sortDir, sortBy, pageNum, pageSize, searchValue, filterBy } = request.query;
+
+        try {
+            if (!sortDir || !sortBy || !pageNum || !pageSize) response.status(400).json({ error: "Queries missing" });
+
+            const queries = {
+                sortBy,
+                sortDir,
+                pageSize: parseInt(pageSize),
+                pageNum: parseInt(pageNum),
+                searchValue: searchValue,
+                filterBy: filterBy,
+            };
+
+            const orderService = new OrderService();
+            const result = await orderService.getAllOrders(queries);
+
+            response.status(200).json(result);
+        } catch (error: any) {
+            errorHandler(error, response);
+        }
+    }
+
+    public async getSingleOrderExecutor(request: Request<ReqParams, {}, {}, {}>, response: Response) {
+
+    }
+}

--- a/src/Order/OrderController.ts
+++ b/src/Order/OrderController.ts
@@ -1,21 +1,16 @@
-import { Request, Response } from 'express';
-import errorHandler from '../Utility/errorHandler.js';
-import OrderService from './OrderService.js';
-import { Status, Task } from '@prisma/client';
+import { Request, Response } from "express";
+import errorHandler from "../Utility/errorHandler.js";
+import OrderService from "./OrderService.js";
+import { Status, Task } from "@prisma/client";
 
 export default class OrderController {
     constructor() {}
 
-    public async getAllOrdersExecutor(
-        request: Request<{}, {}, {}, ReqQuery>,
-        response: Response
-    ) {
-        const { sortDir, sortBy, pageNum, pageSize, searchValue, filterBy } =
-            request.query;
+    public async getAllOrdersExecutor(request: Request<{}, {}, {}, ReqQuery>, response: Response) {
+        const { sortDir, sortBy, pageNum, pageSize, searchValue, filterBy } = request.query;
 
         try {
-            if (!sortDir || !sortBy || !pageNum || !pageSize)
-                response.status(400).json({ error: 'Queries missing' });
+            if (!sortDir || !sortBy || !pageNum || !pageSize) response.status(400).json({ error: "Queries missing" });
 
             const queries = {
                 sortBy,
@@ -35,14 +30,11 @@ export default class OrderController {
         }
     }
 
-    public async getSingleOrderExecutor(
-        request: Request<ReqParams, {}, {}, {}>,
-        response: Response
-    ) {
+    public async getSingleOrderExecutor(request: Request<ReqParams, {}, {}, {}>, response: Response) {
         const id = parseInt(request.params.id);
         try {
             if (!id) {
-                response.status(400).json({ error: 'id is not a number' });
+                response.status(400).json({ error: "id is not a number" });
                 return;
             }
 
@@ -55,19 +47,16 @@ export default class OrderController {
         }
     }
 
-    public async updateOrderStatusExecutor(
-        request: Request<ReqParams, {}, { status: Status }, {}>,
-        response: Response
-    ) {
+    public async updateOrderStatusExecutor(request: Request<ReqParams, {}, { status: Status }, {}>, response: Response) {
         const id = parseInt(request.params.id);
         const { status } = request.body;
 
         try {
             if (!id) {
-                response.status(400).json({ error: 'id is not a number' });
+                response.status(400).json({ error: "id is not a number" });
                 return;
             } else if (!status) {
-                response.status(400).json({ error: 'status is missing' });
+                response.status(400).json({ error: "status is missing" });
                 return;
             }
 
@@ -80,20 +69,17 @@ export default class OrderController {
         }
     }
 
-    public async updateOrderTasksExecutor(
-        request: Request<ReqParams, {}, { tasks: Task[] }, {}>,
-        response: Response
-    ) {
+    public async updateOrderTasksExecutor(request: Request<ReqParams, {}, { tasks: Task[] }, {}>, response: Response) {
         const id = parseInt(request.params.id);
         const tasks = request.body.tasks;
 
         try {
             if (!id) {
-                response.status(400).json({ error: 'id is not a number' });
+                response.status(400).json({ error: "id is not a number" });
                 return;
             } else if (!tasks) {
                 response.status(400).json({
-                    error: 'tasks is missing. Check if it is wrapped in an array',
+                    error: "tasks is missing. Check if it is wrapped in an array",
                 });
                 return;
             }
@@ -109,17 +95,12 @@ export default class OrderController {
 
     // newOrder status, orderStartDate, carId, customerId, tasks
 
-    public async createOrderExecutor(
-        request: Request<{}, {}, NewOrder, {}>,
-        response: Response
-    ) {
+    public async createOrderExecutor(request: Request<{}, {}, NewOrder, {}>, response: Response) {
         const { orderStartDate, carId, customerId, tasks } = request.body;
 
         try {
             if (!orderStartDate || !carId || !customerId || !tasks) {
-                response
-                    .status(400)
-                    .json({ error: 'order parameters are missing' });
+                response.status(400).json({ error: "order parameters are missing" });
                 return;
             }
 

--- a/src/Order/OrderController.ts
+++ b/src/Order/OrderController.ts
@@ -1,18 +1,20 @@
-import { Request, Response } from "express";
-import errorHandler from "../Utility/errorHandler.js";
-import OrderService from "./OrderService.js";
-
-
-
+import { Request, Response } from 'express';
+import errorHandler from '../Utility/errorHandler.js';
+import OrderService from './OrderService.js';
 
 export default class OrderController {
     constructor() {}
 
-    public async getAllOrdersExecutor(request: Request<{}, {}, {}, ReqQuery>, response: Response) {
-        const { sortDir, sortBy, pageNum, pageSize, searchValue, filterBy } = request.query;
+    public async getAllOrdersExecutor(
+        request: Request<{}, {}, {}, ReqQuery>,
+        response: Response
+    ) {
+        const { sortDir, sortBy, pageNum, pageSize, searchValue, filterBy } =
+            request.query;
 
         try {
-            if (!sortDir || !sortBy || !pageNum || !pageSize) response.status(400).json({ error: "Queries missing" });
+            if (!sortDir || !sortBy || !pageNum || !pageSize)
+                response.status(400).json({ error: 'Queries missing' });
 
             const queries = {
                 sortBy,
@@ -32,7 +34,23 @@ export default class OrderController {
         }
     }
 
-    public async getSingleOrderExecutor(request: Request<ReqParams, {}, {}, {}>, response: Response) {
+    public async getSingleOrderExecutor(
+        request: Request<ReqParams, {}, {}, {}>,
+        response: Response
+    ) {
+        const id = parseInt(request.params.id);
+        try {
+            if (!id) {
+                response.status(400).json({ error: 'id is not a number' });
+                return;
+            }
 
+            const orderService = new OrderService();
+            const result = await orderService.getSingleOrder(id);
+
+            response.status(200).json(result);
+        } catch (error: any) {
+            errorHandler(error, response);
+        }
     }
 }

--- a/src/Order/OrderController.ts
+++ b/src/Order/OrderController.ts
@@ -49,7 +49,7 @@ export default class OrderController {
 
     public async updateOrderStatusExecutor(request: Request<ReqParams, {}, { status: Status }, {}>, response: Response) {
         const id = parseInt(request.params.id);
-        const status = request.body.status;
+        const {status} = request.body;
 
         try {
             if (!id) {
@@ -83,9 +83,9 @@ export default class OrderController {
             }
 
             const orderService = new OrderService();
-            await orderService.updateOrderTasks(id, tasks);
+            const result = await orderService.updateOrderTasks(id, tasks);
 
-            response.status(200).json({});
+            response.status(200).json(result);
         } catch (error: any) {
             errorHandler(error, response);
         }

--- a/src/Order/OrderController.ts
+++ b/src/Order/OrderController.ts
@@ -1,20 +1,16 @@
-import { Request, Response } from 'express';
-import errorHandler from '../Utility/errorHandler.js';
-import OrderService from './OrderService.js';
+import { Request, Response } from "express";
+import errorHandler from "../Utility/errorHandler.js";
+import OrderService from "./OrderService.js";
+import { Status, Task } from "@prisma/client";
 
 export default class OrderController {
     constructor() {}
 
-    public async getAllOrdersExecutor(
-        request: Request<{}, {}, {}, ReqQuery>,
-        response: Response
-    ) {
-        const { sortDir, sortBy, pageNum, pageSize, searchValue, filterBy } =
-            request.query;
+    public async getAllOrdersExecutor(request: Request<{}, {}, {}, ReqQuery>, response: Response) {
+        const { sortDir, sortBy, pageNum, pageSize, searchValue, filterBy } = request.query;
 
         try {
-            if (!sortDir || !sortBy || !pageNum || !pageSize)
-                response.status(400).json({ error: 'Queries missing' });
+            if (!sortDir || !sortBy || !pageNum || !pageSize) response.status(400).json({ error: "Queries missing" });
 
             const queries = {
                 sortBy,
@@ -34,14 +30,11 @@ export default class OrderController {
         }
     }
 
-    public async getSingleOrderExecutor(
-        request: Request<ReqParams, {}, {}, {}>,
-        response: Response
-    ) {
+    public async getSingleOrderExecutor(request: Request<ReqParams, {}, {}, {}>, response: Response) {
         const id = parseInt(request.params.id);
         try {
             if (!id) {
-                response.status(400).json({ error: 'id is not a number' });
+                response.status(400).json({ error: "id is not a number" });
                 return;
             }
 
@@ -49,6 +42,50 @@ export default class OrderController {
             const result = await orderService.getSingleOrder(id);
 
             response.status(200).json(result);
+        } catch (error: any) {
+            errorHandler(error, response);
+        }
+    }
+
+    public async updateOrderStatusExecutor(request: Request<ReqParams, {}, { status: Status }, {}>, response: Response) {
+        const id = parseInt(request.params.id);
+        const status = request.body.status;
+
+        try {
+            if (!id) {
+                response.status(400).json({ error: "id is not a number" });
+                return;
+            } else if (!status) {
+                response.status(400).json({ error: "status is missing" });
+                return;
+            }
+
+            const orderService = new OrderService();
+            await orderService.updateOrderStatus(id, status);
+
+            response.status(200).json({});
+        } catch (error: any) {
+            errorHandler(error, response);
+        }
+    }
+
+    public async updateOrderTasksExecutor(request: Request<ReqParams, {}, { tasks: Task[] }, {}>, response: Response) {
+        const id = parseInt(request.params.id);
+        const tasks = request.body.tasks;
+
+        try {
+            if (!id) {
+                response.status(400).json({ error: "id is not a number" });
+                return;
+            } else if (!tasks) {
+                response.status(400).json({ error: "tasks is missing. Check if it is wrapped in an array" });
+                return;
+            }
+
+            const orderService = new OrderService();
+            await orderService.updateOrderTasks(id, tasks);
+
+            response.status(200).json({});
         } catch (error: any) {
             errorHandler(error, response);
         }

--- a/src/Order/OrderController.ts
+++ b/src/Order/OrderController.ts
@@ -1,16 +1,21 @@
-import { Request, Response } from "express";
-import errorHandler from "../Utility/errorHandler.js";
-import OrderService from "./OrderService.js";
-import { Status, Task } from "@prisma/client";
+import { Request, Response } from 'express';
+import errorHandler from '../Utility/errorHandler.js';
+import OrderService from './OrderService.js';
+import { Status, Task } from '@prisma/client';
 
 export default class OrderController {
     constructor() {}
 
-    public async getAllOrdersExecutor(request: Request<{}, {}, {}, ReqQuery>, response: Response) {
-        const { sortDir, sortBy, pageNum, pageSize, searchValue, filterBy } = request.query;
+    public async getAllOrdersExecutor(
+        request: Request<{}, {}, {}, ReqQuery>,
+        response: Response
+    ) {
+        const { sortDir, sortBy, pageNum, pageSize, searchValue, filterBy } =
+            request.query;
 
         try {
-            if (!sortDir || !sortBy || !pageNum || !pageSize) response.status(400).json({ error: "Queries missing" });
+            if (!sortDir || !sortBy || !pageNum || !pageSize)
+                response.status(400).json({ error: 'Queries missing' });
 
             const queries = {
                 sortBy,
@@ -30,11 +35,14 @@ export default class OrderController {
         }
     }
 
-    public async getSingleOrderExecutor(request: Request<ReqParams, {}, {}, {}>, response: Response) {
+    public async getSingleOrderExecutor(
+        request: Request<ReqParams, {}, {}, {}>,
+        response: Response
+    ) {
         const id = parseInt(request.params.id);
         try {
             if (!id) {
-                response.status(400).json({ error: "id is not a number" });
+                response.status(400).json({ error: 'id is not a number' });
                 return;
             }
 
@@ -47,16 +55,19 @@ export default class OrderController {
         }
     }
 
-    public async updateOrderStatusExecutor(request: Request<ReqParams, {}, { status: Status }, {}>, response: Response) {
+    public async updateOrderStatusExecutor(
+        request: Request<ReqParams, {}, { status: Status }, {}>,
+        response: Response
+    ) {
         const id = parseInt(request.params.id);
-        const {status} = request.body;
+        const { status } = request.body;
 
         try {
             if (!id) {
-                response.status(400).json({ error: "id is not a number" });
+                response.status(400).json({ error: 'id is not a number' });
                 return;
             } else if (!status) {
-                response.status(400).json({ error: "status is missing" });
+                response.status(400).json({ error: 'status is missing' });
                 return;
             }
 
@@ -69,21 +80,59 @@ export default class OrderController {
         }
     }
 
-    public async updateOrderTasksExecutor(request: Request<ReqParams, {}, { tasks: Task[] }, {}>, response: Response) {
+    public async updateOrderTasksExecutor(
+        request: Request<ReqParams, {}, { tasks: Task[] }, {}>,
+        response: Response
+    ) {
         const id = parseInt(request.params.id);
         const tasks = request.body.tasks;
 
         try {
             if (!id) {
-                response.status(400).json({ error: "id is not a number" });
+                response.status(400).json({ error: 'id is not a number' });
                 return;
             } else if (!tasks) {
-                response.status(400).json({ error: "tasks is missing. Check if it is wrapped in an array" });
+                response.status(400).json({
+                    error: 'tasks is missing. Check if it is wrapped in an array',
+                });
                 return;
             }
 
             const orderService = new OrderService();
             const result = await orderService.updateOrderTasks(id, tasks);
+
+            response.status(200).json(result);
+        } catch (error: any) {
+            errorHandler(error, response);
+        }
+    }
+
+    // newOrder status, orderStartDate, carId, customerId, tasks
+
+    public async createOrderExecutor(
+        request: Request<{}, {}, NewOrder, {}>,
+        response: Response
+    ) {
+        const { orderStartDate, carId, customerId, tasks } = request.body;
+
+        try {
+            if (!orderStartDate || !carId || !customerId || !tasks) {
+                response
+                    .status(400)
+                    .json({ error: 'order parameters are missing' });
+                return;
+            }
+
+            const newOrder: NewOrder = {
+                status: Status.AWAITING_CUSTOMER,
+                orderStartDate: new Date(orderStartDate),
+                carId,
+                customerId,
+                tasks,
+            };
+
+            const orderService = new OrderService();
+            const result = await orderService.createOrder(newOrder);
 
             response.status(200).json(result);
         } catch (error: any) {

--- a/src/Order/OrderDTO.ts
+++ b/src/Order/OrderDTO.ts
@@ -1,0 +1,24 @@
+
+
+
+
+async function ordersDTO(orders: ResultPagination<any>) {
+    const newData = orders.data?.map((rawOrder) => {
+        return {
+            id: rawOrder.id,
+            customerId: rawOrder.customerId,
+            status: rawOrder.status,
+            orderStartDate: rawOrder.orderStartDate,
+            createdAt: rawOrder.createdAt,
+            updatedAt: rawOrder.updatedAt,
+            registrationNumber: rawOrder.car.registrationNumber,
+        };
+    });
+
+    return {
+        data: newData,
+        metaData: orders.metaData,
+    };
+}
+
+export { ordersDTO };

--- a/src/Order/OrderDTO.ts
+++ b/src/Order/OrderDTO.ts
@@ -1,7 +1,3 @@
-
-
-
-
 async function ordersDTO(orders: ResultPagination<any>) {
     const newData = orders.data?.map((rawOrder) => {
         return {
@@ -21,4 +17,60 @@ async function ordersDTO(orders: ResultPagination<any>) {
     };
 }
 
-export { ordersDTO };
+async function orderDTO(order: SingleOrder) {
+    const DTO: SingleOrderDTO = {
+        id: order.id,
+        status: order.status,
+        orderStartDate: order.orderStartDate,
+        createdAt: order.createdAt,
+        updatedAt: order.updatedAt,
+        car: {
+            id: order.car.id,
+            registrationNumber: order.car.registrationNumber,
+            vinNumber: order.car.vinNumber,
+            brand: order.car.brand,
+            model: order.car.model,
+            modelVariant: order.car.modelVariant,
+            mileage: order.car.mileage,
+        },
+        customer: {
+            id: order.customer.id,
+            firstName: order.customer.firstName,
+            lastName: order.customer.lastName,
+            email: order.customer.email,
+            phone: order.customer.phone,
+        },
+        tasks: order.taskInstances.map((task) => {
+            return {
+                id: task.id,
+                name: task.task.name,
+                description: task.task.description,
+                status: task.status,
+                updatedAt: task.updatedAt,
+                employee: {
+                    firstName: task.employee?.firstName,
+                    lastName: task.employee?.lastName,
+                    department: task.employee?.department,
+                },
+                subtasks: task.subtaskInstances.map((subtask) => {
+                    return {
+                        id: subtask.id,
+                        name: subtask.subtask.name,
+                        description: subtask.subtask.description,
+                        time: subtask.subtask.time,
+                        status: subtask.status,
+                        updatedAt: subtask.updatedAt,
+                    };
+                }),
+            };
+        }),
+    };
+
+    DTO.tasks = DTO.tasks.map((task) =>
+        task.employee?.firstName ? { ...task } : { ...task, employee: null }
+    );
+
+    return DTO;
+}
+
+export { ordersDTO, orderDTO };

--- a/src/Order/OrderRepository.ts
+++ b/src/Order/OrderRepository.ts
@@ -1,5 +1,5 @@
-import { Order, Status } from '.prisma/client';
 import prisma from '../Database/PrismaClient.js';
+import { Order, Status } from '@prisma/client';
 
 export default class OrderRepository implements IPagination<Order> {
     constructor() {}

--- a/src/Order/OrderRepository.ts
+++ b/src/Order/OrderRepository.ts
@@ -1,0 +1,283 @@
+import { Order, Status } from ".prisma/client";
+import prisma from "../Database/PrismaClient.js";
+
+export default class OrderRepository implements IPagination<Order> {
+    constructor() {}
+
+    public async getAllItemsPagination(limit: number, offset: number, sortBy: string, sortDir: string) {
+        const result: ResultPagination<OrderResult> = {};
+
+        result.data = await prisma.order.findMany({
+            skip: offset,
+            take: limit,
+            orderBy: {
+                [sortBy]: sortDir.toLowerCase(),
+            },
+            select: {
+                id: true,
+                customerId: true,
+                status: true,
+                orderStartDate: true,
+                createdAt: true,
+                updatedAt: true,
+                car: {
+                    select: {
+                        registrationNumber: true
+                    }
+                }
+            }
+        });
+
+        result.metaData = {
+            limit,
+            offset,
+            totalCount: await prisma.order.count(),
+        };
+
+        return result;
+    }
+
+    public async getAllItemsSearchPagination(limit: number, offset: number, sortBy: string, sortDir: string, searchValue: string): Promise<ResultPagination<Order>> {
+        const result: ResultPagination<OrderResult> = {};
+
+        result.data = await prisma.order.findMany({
+            skip: offset,
+            take: limit,
+            orderBy: {
+                [sortBy]: sortDir.toLowerCase(),
+            },
+            where: {
+                car: {
+                    registrationNumber: {
+                        contains: searchValue,
+                    },
+                },
+            },
+            select: {
+                id: true,
+                customerId: true,
+                status: true,
+                orderStartDate: true,
+                createdAt: true,
+                updatedAt: true,
+                car: {
+                    select: {
+                        registrationNumber: true,
+                    },
+                },
+            },
+        });
+
+        result.metaData = {
+            limit,
+            offset,
+            totalCount: await prisma.order.count({
+                where: {
+                    car: {
+                        registrationNumber: {
+                            contains: searchValue,
+                        },
+                    },
+                },
+            }),
+        };
+
+        return result;
+    }
+
+    public async getAllItemsSearchNumberPagination(limit: number, offset: number, sortBy: string, sortDir: string, searchValue: number) {
+        const result: ResultPagination<OrderResult> = {};
+
+        result.data = await prisma.order.findMany({
+            skip: offset,
+            take: limit,
+            orderBy: {
+                [sortBy]: sortDir.toLowerCase(),
+            },
+            where: {
+                id: {
+                    equals: searchValue,
+                },
+            },
+            select: {
+                id: true,
+                customerId: true,
+                status: true,
+                orderStartDate: true,
+                createdAt: true,
+                updatedAt: true,
+                car: {
+                    select: {
+                        registrationNumber: true,
+                    },
+                },
+            },
+        });
+
+        result.metaData = {
+            limit,
+            offset,
+            totalCount: await prisma.order.count({
+                where: {
+                    id: {
+                        equals: searchValue,
+                    },
+                },
+            }),
+        };
+
+        return result;
+    }
+
+    public async getAllItemsFilterPagination(limit: number, offset: number, sortBy: string, sortDir: string, filterBy: Status) {
+        const result: ResultPagination<OrderResult> = {};
+
+        result.data = await prisma.order.findMany({
+            skip: offset,
+            take: limit,
+            orderBy: {
+                [sortBy]: sortDir.toLowerCase(),
+            },
+            where: {
+                status: filterBy,
+            },
+            select: {
+                id: true,
+                customerId: true,
+                status: true,
+                orderStartDate: true,
+                createdAt: true,
+                updatedAt: true,
+                car: {
+                    select: {
+                        registrationNumber: true,
+                    },
+                },
+            },
+        });
+
+        result.metaData = {
+            limit,
+            offset,
+            totalCount: await prisma.order.count({
+                where: {
+                    status: filterBy,
+                },
+            }),
+        };
+
+        return result;
+    }
+
+    public async getAllItemsAllPagination(limit: number, offset: number, sortBy: string, sortDir: string, searchValue: string, filterBy: Status) {
+        const result: ResultPagination<OrderResult> = {};
+
+        result.data = await prisma.order.findMany({
+            skip: offset,
+            take: limit,
+            orderBy: {
+                [sortBy]: sortDir.toLowerCase(),
+            },
+            where: {
+                car: {
+                    registrationNumber: {
+                        contains: searchValue,
+                    },
+                },
+                AND: [
+                    {
+                        status: filterBy,
+                    },
+                ],
+            },
+            select: {
+                id: true,
+                customerId: true,
+                status: true,
+                orderStartDate: true,
+                createdAt: true,
+                updatedAt: true,
+                car: {
+                    select: {
+                        registrationNumber: true,
+                    },
+                },
+            },
+        });
+
+        result.metaData = {
+            limit,
+            offset,
+            totalCount: await prisma.order.count({
+                where: {
+                    car: {
+                        registrationNumber: {
+                            contains: searchValue,
+                        },
+                    },
+                    AND: [
+                        {
+                            status: filterBy,
+                        },
+                    ],
+                },
+            }),
+        };
+
+        return result;
+    }
+
+    public async getAllItemsNumberAllPagination(limit: number, offset: number, sortBy: string, sortDir: string, searchValue: number, filterBy: Status) {
+        const result: ResultPagination<OrderResult> = {};
+
+        result.data = await prisma.order.findMany({
+            skip: offset,
+            take: limit,
+            orderBy: {
+                [sortBy]: sortDir.toLowerCase(),
+            },
+            where: {
+                id: {
+                    equals: searchValue,
+                },
+                AND: [
+                    {
+                        status: filterBy,
+                    },
+                ],
+            },
+            select: {
+                id: true,
+                customerId: true,
+                status: true,
+                orderStartDate: true,
+                createdAt: true,
+                updatedAt: true,
+                car: {
+                    select: {
+                        registrationNumber: true,
+                    },
+                },
+            },
+        });
+
+        result.metaData = {
+            limit,
+            offset,
+            totalCount: await prisma.order.count({
+                where: {
+                    id: {
+                        equals: searchValue,
+                    },
+                    AND: [
+                        {
+                            status: filterBy,
+                        },
+                    ],
+                },
+            }),
+        };
+
+        return result;
+    }
+}

--- a/src/Order/OrderRepository.ts
+++ b/src/Order/OrderRepository.ts
@@ -1,5 +1,5 @@
 import prisma from '../Database/PrismaClient.js';
-import { Order, Status, Task, TaskInstance } from '@prisma/client';
+import {Order, Status, Task, TaskInstance} from '@prisma/client';
 
 export default class OrderRepository implements IPagination<Order> {
     constructor() {}
@@ -399,7 +399,7 @@ export default class OrderRepository implements IPagination<Order> {
     }
 
     public async updateOrderStatus(id: number, status: Status) {
-        return await prisma.order.update({
+        return prisma.order.update({
             where: {
                 id: id,
             },
@@ -444,7 +444,7 @@ export default class OrderRepository implements IPagination<Order> {
             subtaskNumber: number;
         }[]
     ) {
-        const result = await prisma.$transaction(async (prisma) => {
+        return prisma.$transaction(async (prisma) => {
             // Delete task and subtask instances if there are tasks to delete
             if (tasksToDelete.length > 0) {
                 await prisma.subtaskInstance.deleteMany({
@@ -497,10 +497,10 @@ export default class OrderRepository implements IPagination<Order> {
                         );
                         return taskInstance
                             ? {
-                                  status: 'PENDING',
-                                  subtaskId: subtask.subtaskId,
-                                  taskInstanceId: taskInstance.id,
-                              }
+                                status: 'PENDING',
+                                subtaskId: subtask.subtaskId,
+                                taskInstanceId: taskInstance.id,
+                            }
                             : null;
                     })
                     .filter((item) => item !== null);
@@ -513,7 +513,6 @@ export default class OrderRepository implements IPagination<Order> {
                 });
             }
         });
-        return result;
     }
 
     public async createOrder(
@@ -524,7 +523,7 @@ export default class OrderRepository implements IPagination<Order> {
             subtaskNumber: number;
         }[]
     ) {
-        const result = await prisma.$transaction(async (prisma) => {
+        return prisma.$transaction(async (prisma) => {
             // Create order
             const newOrder = await prisma.order.create({
                 data: {
@@ -567,10 +566,10 @@ export default class OrderRepository implements IPagination<Order> {
                     );
                     return taskInstance
                         ? {
-                              status: Status.PENDING,
-                              subtaskId: subtask.subtaskId,
-                              taskInstanceId: taskInstance.id,
-                          }
+                            status: Status.PENDING,
+                            subtaskId: subtask.subtaskId,
+                            taskInstanceId: taskInstance.id,
+                        }
                         : null;
                 })
                 .filter((item) => item !== null);
@@ -579,6 +578,5 @@ export default class OrderRepository implements IPagination<Order> {
                 data: subtaskInstanceData,
             });
         });
-        return result;
     }
 }

--- a/src/Order/OrderRepository.ts
+++ b/src/Order/OrderRepository.ts
@@ -1,15 +1,10 @@
-import prisma from '../Database/PrismaClient.js';
-import {Order, Status, Task, TaskInstance} from '@prisma/client';
+import prisma from "../Database/PrismaClient.js";
+import { Order, Status, Task, TaskInstance } from "@prisma/client";
 
 export default class OrderRepository implements IPagination<Order> {
     constructor() {}
 
-    public async getAllItemsPagination(
-        limit: number,
-        offset: number,
-        sortBy: string,
-        sortDir: string
-    ) {
+    public async getAllItemsPagination(limit: number, offset: number, sortBy: string, sortDir: string) {
         const result: ResultPagination<OrderResult> = {};
 
         result.data = await prisma.order.findMany({
@@ -42,13 +37,7 @@ export default class OrderRepository implements IPagination<Order> {
         return result;
     }
 
-    public async getAllItemsSearchPagination(
-        limit: number,
-        offset: number,
-        sortBy: string,
-        sortDir: string,
-        searchValue: string
-    ): Promise<ResultPagination<Order>> {
+    public async getAllItemsSearchPagination(limit: number, offset: number, sortBy: string, sortDir: string, searchValue: string): Promise<ResultPagination<Order>> {
         const result: ResultPagination<OrderResult> = {};
 
         result.data = await prisma.order.findMany({
@@ -96,13 +85,7 @@ export default class OrderRepository implements IPagination<Order> {
         return result;
     }
 
-    public async getAllItemsSearchNumberPagination(
-        limit: number,
-        offset: number,
-        sortBy: string,
-        sortDir: string,
-        searchValue: number
-    ) {
+    public async getAllItemsSearchNumberPagination(limit: number, offset: number, sortBy: string, sortDir: string, searchValue: number) {
         const result: ResultPagination<OrderResult> = {};
 
         result.data = await prisma.order.findMany({
@@ -146,13 +129,7 @@ export default class OrderRepository implements IPagination<Order> {
         return result;
     }
 
-    public async getAllItemsFilterPagination(
-        limit: number,
-        offset: number,
-        sortBy: string,
-        sortDir: string,
-        filterBy: Status
-    ) {
+    public async getAllItemsFilterPagination(limit: number, offset: number, sortBy: string, sortDir: string, filterBy: Status) {
         const result: ResultPagination<OrderResult> = {};
 
         result.data = await prisma.order.findMany({
@@ -192,14 +169,7 @@ export default class OrderRepository implements IPagination<Order> {
         return result;
     }
 
-    public async getAllItemsAllPagination(
-        limit: number,
-        offset: number,
-        sortBy: string,
-        sortDir: string,
-        searchValue: string,
-        filterBy: Status
-    ) {
+    public async getAllItemsAllPagination(limit: number, offset: number, sortBy: string, sortDir: string, searchValue: string, filterBy: Status) {
         const result: ResultPagination<OrderResult> = {};
 
         result.data = await prisma.order.findMany({
@@ -257,14 +227,7 @@ export default class OrderRepository implements IPagination<Order> {
         return result;
     }
 
-    public async getAllItemsNumberAllPagination(
-        limit: number,
-        offset: number,
-        sortBy: string,
-        sortDir: string,
-        searchValue: number,
-        filterBy: Status
-    ) {
+    public async getAllItemsNumberAllPagination(limit: number, offset: number, sortBy: string, sortDir: string, searchValue: number, filterBy: Status) {
         const result: ResultPagination<OrderResult> = {};
 
         result.data = await prisma.order.findMany({
@@ -466,14 +429,13 @@ export default class OrderRepository implements IPagination<Order> {
 
             // Variables to store new task instances and subtask instance data
             let newTaskInstances: TaskInstance[] = [];
-            let subtaskInstanceData: /*{status: Status, subtaskId: number, taskInstanceId: number}*/ any[] =
-                [];
+            let subtaskInstanceData: /*{status: Status, subtaskId: number, taskInstanceId: number}*/ any[] = [];
 
             // Create new task instances if there are tasks to add
             if (tasksToAdd.length > 0) {
                 await prisma.taskInstance.createMany({
                     data: tasksToAdd.map((task) => ({
-                        status: 'PENDING',
+                        status: Status.PENDING,
                         taskId: task.id,
                         orderId: orderId,
                     })),
@@ -492,15 +454,13 @@ export default class OrderRepository implements IPagination<Order> {
                 // Map each subtask to its corresponding task instance
                 subtaskInstanceData = subtasksToAdd
                     .map((subtask) => {
-                        const taskInstance = newTaskInstances.find(
-                            (instance) => instance.taskId === subtask.taskId
-                        );
+                        const taskInstance = newTaskInstances.find((instance) => instance.taskId === subtask.taskId);
                         return taskInstance
                             ? {
-                                status: 'PENDING',
-                                subtaskId: subtask.subtaskId,
-                                taskInstanceId: taskInstance.id,
-                            }
+                                  status: Status.PENDING,
+                                  subtaskId: subtask.subtaskId,
+                                  taskInstanceId: taskInstance.id,
+                              }
                             : null;
                     })
                     .filter((item) => item !== null);
@@ -536,8 +496,7 @@ export default class OrderRepository implements IPagination<Order> {
 
             // Variables to store new task instances and subtask instance data
             let newTaskInstances: TaskInstance[] = [];
-            let subtaskInstanceData: /*{status: Status, subtaskId: number, taskInstanceId: number}*/ any[] =
-                [];
+            let subtaskInstanceData: /*{status: Status, subtaskId: number, taskInstanceId: number}*/ any[] = [];
 
             // Create task instances
             await prisma.taskInstance.createMany({
@@ -561,15 +520,13 @@ export default class OrderRepository implements IPagination<Order> {
             // Create subtask instances
             subtaskInstanceData = subtasks
                 .map((subtask) => {
-                    const taskInstance = newTaskInstances.find(
-                        (instance: any) => instance.taskId === subtask.taskId
-                    );
+                    const taskInstance = newTaskInstances.find((instance: any) => instance.taskId === subtask.taskId);
                     return taskInstance
                         ? {
-                            status: Status.PENDING,
-                            subtaskId: subtask.subtaskId,
-                            taskInstanceId: taskInstance.id,
-                        }
+                              status: Status.PENDING,
+                              subtaskId: subtask.subtaskId,
+                              taskInstanceId: taskInstance.id,
+                          }
                         : null;
                 })
                 .filter((item) => item !== null);

--- a/src/Order/OrderRepository.ts
+++ b/src/Order/OrderRepository.ts
@@ -1,10 +1,15 @@
-import prisma from "../Database/PrismaClient.js";
-import { Order, Status, Task, TaskInstance, SubtaskInstance } from "@prisma/client";
+import prisma from '../Database/PrismaClient.js';
+import { Order, Status, Task, TaskInstance } from '@prisma/client';
 
 export default class OrderRepository implements IPagination<Order> {
     constructor() {}
 
-    public async getAllItemsPagination(limit: number, offset: number, sortBy: string, sortDir: string) {
+    public async getAllItemsPagination(
+        limit: number,
+        offset: number,
+        sortBy: string,
+        sortDir: string
+    ) {
         const result: ResultPagination<OrderResult> = {};
 
         result.data = await prisma.order.findMany({
@@ -37,7 +42,13 @@ export default class OrderRepository implements IPagination<Order> {
         return result;
     }
 
-    public async getAllItemsSearchPagination(limit: number, offset: number, sortBy: string, sortDir: string, searchValue: string): Promise<ResultPagination<Order>> {
+    public async getAllItemsSearchPagination(
+        limit: number,
+        offset: number,
+        sortBy: string,
+        sortDir: string,
+        searchValue: string
+    ): Promise<ResultPagination<Order>> {
         const result: ResultPagination<OrderResult> = {};
 
         result.data = await prisma.order.findMany({
@@ -85,7 +96,13 @@ export default class OrderRepository implements IPagination<Order> {
         return result;
     }
 
-    public async getAllItemsSearchNumberPagination(limit: number, offset: number, sortBy: string, sortDir: string, searchValue: number) {
+    public async getAllItemsSearchNumberPagination(
+        limit: number,
+        offset: number,
+        sortBy: string,
+        sortDir: string,
+        searchValue: number
+    ) {
         const result: ResultPagination<OrderResult> = {};
 
         result.data = await prisma.order.findMany({
@@ -129,7 +146,13 @@ export default class OrderRepository implements IPagination<Order> {
         return result;
     }
 
-    public async getAllItemsFilterPagination(limit: number, offset: number, sortBy: string, sortDir: string, filterBy: Status) {
+    public async getAllItemsFilterPagination(
+        limit: number,
+        offset: number,
+        sortBy: string,
+        sortDir: string,
+        filterBy: Status
+    ) {
         const result: ResultPagination<OrderResult> = {};
 
         result.data = await prisma.order.findMany({
@@ -169,7 +192,14 @@ export default class OrderRepository implements IPagination<Order> {
         return result;
     }
 
-    public async getAllItemsAllPagination(limit: number, offset: number, sortBy: string, sortDir: string, searchValue: string, filterBy: Status) {
+    public async getAllItemsAllPagination(
+        limit: number,
+        offset: number,
+        sortBy: string,
+        sortDir: string,
+        searchValue: string,
+        filterBy: Status
+    ) {
         const result: ResultPagination<OrderResult> = {};
 
         result.data = await prisma.order.findMany({
@@ -227,7 +257,14 @@ export default class OrderRepository implements IPagination<Order> {
         return result;
     }
 
-    public async getAllItemsNumberAllPagination(limit: number, offset: number, sortBy: string, sortDir: string, searchValue: number, filterBy: Status) {
+    public async getAllItemsNumberAllPagination(
+        limit: number,
+        offset: number,
+        sortBy: string,
+        sortDir: string,
+        searchValue: number,
+        filterBy: Status
+    ) {
         const result: ResultPagination<OrderResult> = {};
 
         result.data = await prisma.order.findMany({
@@ -349,7 +386,7 @@ export default class OrderRepository implements IPagination<Order> {
             },
         });
     }
-    
+
     public async getOrderStatus(id: number) {
         return prisma.order.findUniqueOrThrow({
             where: {
@@ -362,7 +399,6 @@ export default class OrderRepository implements IPagination<Order> {
     }
 
     public async updateOrderStatus(id: number, status: Status) {
-        
         return await prisma.order.update({
             where: {
                 id: id,
@@ -378,133 +414,98 @@ export default class OrderRepository implements IPagination<Order> {
             where: {
                 id: id,
             },
-            include: { taskInstances: {
-                select: {
-                    id: true,
+            include: {
+                taskInstances: {
+                    select: {
+                        id: true,
+                    },
                 },
-            } },
-        })
+            },
+        });
     }
 
     public async getTaskSubtasks(tasks: Task[]) {
         return prisma.taskSubtask.findMany({
             where: {
                 taskId: {
-                    in: tasks.map(task => task.id),
+                    in: tasks.map((task) => task.id),
                 },
             },
         });
     }
 
-    // public async updateOrderTasks(orderId: number, tasksToDelete: {id:number}[], tasksToAdd: Task[], subtasksToAdd: {
-    //     taskId: number;
-    //     subtaskId: number;
-    //     subtaskNumber: number;
-    // }[]) {
-
-    //    const result =  await prisma.$transaction(async (prisma) => {
-
-    //         await prisma.subtaskInstance.deleteMany({
-    //             where: {
-    //                 taskInstanceId: {
-    //                     in: tasksToDelete.map(task => task.id),
-    //                 },
-    //             },
-    //         });
-            
-    //         await prisma.taskInstance.deleteMany({
-    //             where: {
-    //                 id: {
-    //                     in: tasksToDelete.map(task => task.id),
-    //                 },
-    //             },
-    //         });
-
-    //         await prisma.taskInstance.createMany({
-    //             data: tasksToAdd.map(task => {
-    //                 return {
-    //                     status: "PENDING",
-    //                     taskId: task.id,
-    //                     orderId: orderId,
-    //                 }
-    //             }),
-    //         });
-
-    //         // await prisma.subtaskInstance.createMany({
-    //         //     data: subtasksToAdd.map(subtask => {
-    //         //         return {
-    //         //             status: "PENDING",
-    //         //             subtaskId: subtask.subtaskId,
-    //         //             taskInstanceId: {
-    //         //                 in: tasksToAdd.map(task => task.id),
-    //         //             },
-    //         //         }
-    //         //     }),
-    //         // });
-    //         });
-    //     return result;
-    // }
-
-    public async updateOrderTasks(orderId: number, tasksToDelete: {id:number}[], tasksToAdd: Task[], subtasksToAdd: {
-        taskId: number;
-        subtaskId: number;
-        subtaskNumber: number;
-    }[]) {
+    public async updateOrderTasks(
+        orderId: number,
+        tasksToDelete: { id: number }[],
+        tasksToAdd: Task[],
+        subtasksToAdd: {
+            taskId: number;
+            subtaskId: number;
+            subtaskNumber: number;
+        }[]
+    ) {
         const result = await prisma.$transaction(async (prisma) => {
             // Delete task and subtask instances if there are tasks to delete
             if (tasksToDelete.length > 0) {
                 await prisma.subtaskInstance.deleteMany({
                     where: {
                         taskInstanceId: {
-                            in: tasksToDelete.map(task => task.id),
+                            in: tasksToDelete.map((task) => task.id),
                         },
                     },
                 });
-    
+
                 await prisma.taskInstance.deleteMany({
                     where: {
                         id: {
-                            in: tasksToDelete.map(task => task.id),
+                            in: tasksToDelete.map((task) => task.id),
                         },
                     },
                 });
             }
-    
+
             // Variables to store new task instances and subtask instance data
             let newTaskInstances: TaskInstance[] = [];
-            let subtaskInstanceData: /*{status: Status, subtaskId: number, taskInstanceId: number}*/ any[]= [];
-    
+            let subtaskInstanceData: /*{status: Status, subtaskId: number, taskInstanceId: number}*/ any[] =
+                [];
+
             // Create new task instances if there are tasks to add
             if (tasksToAdd.length > 0) {
                 await prisma.taskInstance.createMany({
-                    data: tasksToAdd.map(task => ({
-                        status: "PENDING",
+                    data: tasksToAdd.map((task) => ({
+                        status: 'PENDING',
                         taskId: task.id,
                         orderId: orderId,
                     })),
                 });
-    
+
                 // Fetch the newly created task instances to get their IDs
                 newTaskInstances = await prisma.taskInstance.findMany({
                     where: {
                         orderId: orderId,
                         taskId: {
-                            in: tasksToAdd.map(task => task.id),
+                            in: tasksToAdd.map((task) => task.id),
                         },
                     },
                 });
-    
+
                 // Map each subtask to its corresponding task instance
-                subtaskInstanceData = subtasksToAdd.map(subtask => {
-                    const taskInstance = newTaskInstances.find(instance => instance.taskId === subtask.taskId);
-                    return taskInstance ? {
-                        status: "PENDING",
-                        subtaskId: subtask.subtaskId,
-                        taskInstanceId: taskInstance.id,
-                    } : null;
-                }).filter(item => item !== null);
+                subtaskInstanceData = subtasksToAdd
+                    .map((subtask) => {
+                        const taskInstance = newTaskInstances.find(
+                            (instance) => instance.taskId === subtask.taskId
+                        );
+                        return taskInstance
+                            ? {
+                                  status: 'PENDING',
+                                  subtaskId: subtask.subtaskId,
+                                  taskInstanceId: taskInstance.id,
+                              }
+                            : null;
+                    })
+                    .filter((item) => item !== null);
             }
-    
+
             // Create new subtask instances if there are subtasks to add
             if (subtaskInstanceData.length > 0) {
                 await prisma.subtaskInstance.createMany({
@@ -515,5 +516,69 @@ export default class OrderRepository implements IPagination<Order> {
         return result;
     }
 
+    public async createOrder(
+        order: NewOrder,
+        subtasks: {
+            taskId: number;
+            subtaskId: number;
+            subtaskNumber: number;
+        }[]
+    ) {
+        const result = await prisma.$transaction(async (prisma) => {
+            // Create order
+            const newOrder = await prisma.order.create({
+                data: {
+                    customerId: order.customerId,
+                    carId: order.carId,
+                    status: Status.AWAITING_CUSTOMER,
+                    orderStartDate: order.orderStartDate,
+                },
+            });
 
+            // Variables to store new task instances and subtask instance data
+            let newTaskInstances: TaskInstance[] = [];
+            let subtaskInstanceData: /*{status: Status, subtaskId: number, taskInstanceId: number}*/ any[] =
+                [];
+
+            // Create task instances
+            await prisma.taskInstance.createMany({
+                data: order.tasks.map((task) => ({
+                    status: Status.PENDING,
+                    taskId: task.id,
+                    orderId: newOrder.id,
+                })),
+            });
+
+            // Fetch the newly created task instances to get their IDs
+            newTaskInstances = await prisma.taskInstance.findMany({
+                where: {
+                    orderId: newOrder.id,
+                    taskId: {
+                        in: order.tasks.map((task) => task.id),
+                    },
+                },
+            });
+
+            // Create subtask instances
+            subtaskInstanceData = subtasks
+                .map((subtask) => {
+                    const taskInstance = newTaskInstances.find(
+                        (instance: any) => instance.taskId === subtask.taskId
+                    );
+                    return taskInstance
+                        ? {
+                              status: Status.PENDING,
+                              subtaskId: subtask.subtaskId,
+                              taskInstanceId: taskInstance.id,
+                          }
+                        : null;
+                })
+                .filter((item) => item !== null);
+
+            await prisma.subtaskInstance.createMany({
+                data: subtaskInstanceData,
+            });
+        });
+        return result;
+    }
 }

--- a/src/Order/OrderRepository.ts
+++ b/src/Order/OrderRepository.ts
@@ -434,55 +434,6 @@ export default class OrderRepository implements IPagination<Order> {
         });
     }
 
-    // public async updateOrderTasks(orderId: number, tasksToDelete: {id:number}[], tasksToAdd: Task[], subtasksToAdd: {
-    //     taskId: number;
-    //     subtaskId: number;
-    //     subtaskNumber: number;
-    // }[]) {
-
-    //    const result =  await prisma.$transaction(async (prisma) => {
-
-    //         await prisma.subtaskInstance.deleteMany({
-    //             where: {
-    //                 taskInstanceId: {
-    //                     in: tasksToDelete.map(task => task.id),
-    //                 },
-    //             },
-    //         });
-
-    //         await prisma.taskInstance.deleteMany({
-    //             where: {
-    //                 id: {
-    //                     in: tasksToDelete.map(task => task.id),
-    //                 },
-    //             },
-    //         });
-
-    //         await prisma.taskInstance.createMany({
-    //             data: tasksToAdd.map(task => {
-    //                 return {
-    //                     status: "PENDING",
-    //                     taskId: task.id,
-    //                     orderId: orderId,
-    //                 }
-    //             }),
-    //         });
-
-    //         // await prisma.subtaskInstance.createMany({
-    //         //     data: subtasksToAdd.map(subtask => {
-    //         //         return {
-    //         //             status: "PENDING",
-    //         //             subtaskId: subtask.subtaskId,
-    //         //             taskInstanceId: {
-    //         //                 in: tasksToAdd.map(task => task.id),
-    //         //             },
-    //         //         }
-    //         //     }),
-    //         // });
-    //         });
-    //     return result;
-    // }
-
     public async updateOrderTasks(
         orderId: number,
         tasksToDelete: { id: number }[],

--- a/src/Order/OrderRepository.ts
+++ b/src/Order/OrderRepository.ts
@@ -1,10 +1,15 @@
-import { Order, Status } from ".prisma/client";
-import prisma from "../Database/PrismaClient.js";
+import { Order, Status } from '.prisma/client';
+import prisma from '../Database/PrismaClient.js';
 
 export default class OrderRepository implements IPagination<Order> {
     constructor() {}
 
-    public async getAllItemsPagination(limit: number, offset: number, sortBy: string, sortDir: string) {
+    public async getAllItemsPagination(
+        limit: number,
+        offset: number,
+        sortBy: string,
+        sortDir: string
+    ) {
         const result: ResultPagination<OrderResult> = {};
 
         result.data = await prisma.order.findMany({
@@ -22,10 +27,10 @@ export default class OrderRepository implements IPagination<Order> {
                 updatedAt: true,
                 car: {
                     select: {
-                        registrationNumber: true
-                    }
-                }
-            }
+                        registrationNumber: true,
+                    },
+                },
+            },
         });
 
         result.metaData = {
@@ -37,7 +42,13 @@ export default class OrderRepository implements IPagination<Order> {
         return result;
     }
 
-    public async getAllItemsSearchPagination(limit: number, offset: number, sortBy: string, sortDir: string, searchValue: string): Promise<ResultPagination<Order>> {
+    public async getAllItemsSearchPagination(
+        limit: number,
+        offset: number,
+        sortBy: string,
+        sortDir: string,
+        searchValue: string
+    ): Promise<ResultPagination<Order>> {
         const result: ResultPagination<OrderResult> = {};
 
         result.data = await prisma.order.findMany({
@@ -85,7 +96,13 @@ export default class OrderRepository implements IPagination<Order> {
         return result;
     }
 
-    public async getAllItemsSearchNumberPagination(limit: number, offset: number, sortBy: string, sortDir: string, searchValue: number) {
+    public async getAllItemsSearchNumberPagination(
+        limit: number,
+        offset: number,
+        sortBy: string,
+        sortDir: string,
+        searchValue: number
+    ) {
         const result: ResultPagination<OrderResult> = {};
 
         result.data = await prisma.order.findMany({
@@ -129,7 +146,13 @@ export default class OrderRepository implements IPagination<Order> {
         return result;
     }
 
-    public async getAllItemsFilterPagination(limit: number, offset: number, sortBy: string, sortDir: string, filterBy: Status) {
+    public async getAllItemsFilterPagination(
+        limit: number,
+        offset: number,
+        sortBy: string,
+        sortDir: string,
+        filterBy: Status
+    ) {
         const result: ResultPagination<OrderResult> = {};
 
         result.data = await prisma.order.findMany({
@@ -169,7 +192,14 @@ export default class OrderRepository implements IPagination<Order> {
         return result;
     }
 
-    public async getAllItemsAllPagination(limit: number, offset: number, sortBy: string, sortDir: string, searchValue: string, filterBy: Status) {
+    public async getAllItemsAllPagination(
+        limit: number,
+        offset: number,
+        sortBy: string,
+        sortDir: string,
+        searchValue: string,
+        filterBy: Status
+    ) {
         const result: ResultPagination<OrderResult> = {};
 
         result.data = await prisma.order.findMany({
@@ -227,7 +257,14 @@ export default class OrderRepository implements IPagination<Order> {
         return result;
     }
 
-    public async getAllItemsNumberAllPagination(limit: number, offset: number, sortBy: string, sortDir: string, searchValue: number, filterBy: Status) {
+    public async getAllItemsNumberAllPagination(
+        limit: number,
+        offset: number,
+        sortBy: string,
+        sortDir: string,
+        searchValue: number,
+        filterBy: Status
+    ) {
         const result: ResultPagination<OrderResult> = {};
 
         result.data = await prisma.order.findMany({
@@ -279,5 +316,74 @@ export default class OrderRepository implements IPagination<Order> {
         };
 
         return result;
+    }
+
+    public async getSingleOrder(id: number) {
+        return prisma.order.findUniqueOrThrow({
+            where: {
+                id: id,
+            },
+            select: {
+                id: true,
+                status: true,
+                orderStartDate: true,
+                createdAt: true,
+                updatedAt: true,
+                car: {
+                    select: {
+                        id: true,
+                        registrationNumber: true,
+                        vinNumber: true,
+                        brand: true,
+                        model: true,
+                        modelVariant: true,
+                        mileage: true,
+                    },
+                },
+                customer: {
+                    select: {
+                        id: true,
+                        firstName: true,
+                        lastName: true,
+                        email: true,
+                        phone: true,
+                    },
+                },
+                taskInstances: {
+                    select: {
+                        id: true,
+                        status: true,
+                        updatedAt: true,
+                        employee: {
+                            select: {
+                                firstName: true,
+                                lastName: true,
+                                department: true,
+                            },
+                        },
+                        task: {
+                            select: {
+                                name: true,
+                                description: true,
+                            },
+                        },
+                        subtaskInstances: {
+                            select: {
+                                id: true,
+                                status: true,
+                                updatedAt: true,
+                                subtask: {
+                                    select: {
+                                        name: true,
+                                        time: true,
+                                        description: true,
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        });
     }
 }

--- a/src/Order/OrderRouter.ts
+++ b/src/Order/OrderRouter.ts
@@ -6,3 +6,5 @@ const orderController = new OrderController();
 
 orderRouter.get('/orders', orderController.getAllOrdersExecutor);
 orderRouter.get('/orders/:id', orderController.getSingleOrderExecutor);
+orderRouter.patch("/orders/:id/status", orderController.updateOrderStatusExecutor);
+orderRouter.patch("/orders/:id/tasks");

--- a/src/Order/OrderRouter.ts
+++ b/src/Order/OrderRouter.ts
@@ -6,5 +6,12 @@ const orderController = new OrderController();
 
 orderRouter.get('/orders', orderController.getAllOrdersExecutor);
 orderRouter.get('/orders/:id', orderController.getSingleOrderExecutor);
-orderRouter.patch("/orders/:id/status", orderController.updateOrderStatusExecutor);
-orderRouter.patch("/orders/:id/tasks", orderController.updateOrderTasksExecutor);
+orderRouter.patch(
+    '/orders/:id/status',
+    orderController.updateOrderStatusExecutor
+);
+orderRouter.patch(
+    '/orders/:id/tasks',
+    orderController.updateOrderTasksExecutor
+);
+orderRouter.post('/orders', orderController.createOrderExecutor);

--- a/src/Order/OrderRouter.ts
+++ b/src/Order/OrderRouter.ts
@@ -7,4 +7,4 @@ const orderController = new OrderController();
 orderRouter.get('/orders', orderController.getAllOrdersExecutor);
 orderRouter.get('/orders/:id', orderController.getSingleOrderExecutor);
 orderRouter.patch("/orders/:id/status", orderController.updateOrderStatusExecutor);
-orderRouter.patch("/orders/:id/tasks");
+orderRouter.patch("/orders/:id/tasks", orderController.updateOrderTasksExecutor);

--- a/src/Order/OrderRouter.ts
+++ b/src/Order/OrderRouter.ts
@@ -1,0 +1,9 @@
+import express from "express";
+import OrderController from "./OrderController.js";
+
+
+export const orderRouter = express.Router();
+const orderController = new OrderController();
+
+orderRouter.get("/orders", orderController.getAllOrdersExecutor)
+// orderRouter.get("/orders/:id", orderController.)

--- a/src/Order/OrderRouter.ts
+++ b/src/Order/OrderRouter.ts
@@ -1,9 +1,8 @@
-import express from "express";
-import OrderController from "./OrderController.js";
-
+import express from 'express';
+import OrderController from './OrderController.js';
 
 export const orderRouter = express.Router();
 const orderController = new OrderController();
 
-orderRouter.get("/orders", orderController.getAllOrdersExecutor)
-// orderRouter.get("/orders/:id", orderController.)
+orderRouter.get('/orders', orderController.getAllOrdersExecutor);
+orderRouter.get('/orders/:id', orderController.getSingleOrderExecutor);

--- a/src/Order/OrderService.ts
+++ b/src/Order/OrderService.ts
@@ -1,5 +1,5 @@
 import Pagination from '../Utility/Pagination.js';
-import { ordersDTO } from './OrderDTO.js';
+import { orderDTO, ordersDTO } from './OrderDTO.js';
 import OrderRepository from './OrderRepository.js';
 
 export default class OrderService extends Pagination {
@@ -94,7 +94,6 @@ export default class OrderService extends Pagination {
     public async getSingleOrder(id: number) {
         const orderRepository = new OrderRepository();
         const result = await orderRepository.getSingleOrder(id);
-        return result;
-        // return orderDTO(result);
+        return orderDTO(result);
     }
 }

--- a/src/Order/OrderService.ts
+++ b/src/Order/OrderService.ts
@@ -1,51 +1,100 @@
-import Pagination from "../Utility/Pagination.js";
-import { ordersDTO } from "./OrderDTO.js";
-import OrderRepository from "./OrderRepository.js";
-
-
+import Pagination from '../Utility/Pagination.js';
+import { ordersDTO } from './OrderDTO.js';
+import OrderRepository from './OrderRepository.js';
 
 export default class OrderService extends Pagination {
     constructor() {
         super();
     }
 
-    public async getAllOrders({ pageNum, pageSize, sortBy, sortDir, filterBy, searchValue }: OrderQueryType) {
+    public async getAllOrders({
+        pageNum,
+        pageSize,
+        sortBy,
+        sortDir,
+        filterBy,
+        searchValue,
+    }: OrderQueryType) {
         const orderRepository = new OrderRepository();
         this.calculateOffset(pageSize, pageNum);
         const numericRegex: RegExp = /^[0-9]+$/;
-        
+
         let orderResult: ResultPagination<any> = {};
 
         if (searchValue && filterBy) {
-
             if (numericRegex.test(searchValue)) {
                 const searchValueInt = parseInt(searchValue);
-                orderResult = await orderRepository.getAllItemsNumberAllPagination(pageSize, this.offset, sortBy, sortDir, searchValueInt, filterBy);
+                orderResult =
+                    await orderRepository.getAllItemsNumberAllPagination(
+                        pageSize,
+                        this.offset,
+                        sortBy,
+                        sortDir,
+                        searchValueInt,
+                        filterBy
+                    );
             } else {
-                orderResult = await orderRepository.getAllItemsAllPagination(pageSize, this.offset, sortBy, sortDir, searchValue, filterBy);
+                orderResult = await orderRepository.getAllItemsAllPagination(
+                    pageSize,
+                    this.offset,
+                    sortBy,
+                    sortDir,
+                    searchValue,
+                    filterBy
+                );
             }
-            
+
             return ordersDTO(orderResult);
         }
 
         if (searchValue) {
-            
             if (numericRegex.test(searchValue)) {
-                const searchValueInt = parseInt(searchValue)
-                orderResult = await orderRepository.getAllItemsSearchNumberPagination(pageSize, this.offset, sortBy, sortDir, searchValueInt);
+                const searchValueInt = parseInt(searchValue);
+                orderResult =
+                    await orderRepository.getAllItemsSearchNumberPagination(
+                        pageSize,
+                        this.offset,
+                        sortBy,
+                        sortDir,
+                        searchValueInt
+                    );
             } else {
-                orderResult = await orderRepository.getAllItemsSearchPagination(pageSize, this.offset, sortBy, sortDir, searchValue);
+                orderResult = await orderRepository.getAllItemsSearchPagination(
+                    pageSize,
+                    this.offset,
+                    sortBy,
+                    sortDir,
+                    searchValue
+                );
             }
 
             return ordersDTO(orderResult);
         }
 
         if (filterBy) {
-            orderResult = await orderRepository.getAllItemsFilterPagination(pageSize, this.offset, sortBy, sortDir, filterBy);
+            orderResult = await orderRepository.getAllItemsFilterPagination(
+                pageSize,
+                this.offset,
+                sortBy,
+                sortDir,
+                filterBy
+            );
             return ordersDTO(orderResult);
         }
 
-        orderResult = await orderRepository.getAllItemsPagination(pageSize, this.offset, sortBy, sortDir);
+        orderResult = await orderRepository.getAllItemsPagination(
+            pageSize,
+            this.offset,
+            sortBy,
+            sortDir
+        );
         return ordersDTO(orderResult);
+    }
+
+    public async getSingleOrder(id: number) {
+        const orderRepository = new OrderRepository();
+        const result = await orderRepository.getSingleOrder(id);
+        return result;
+        // return orderDTO(result);
     }
 }

--- a/src/Order/OrderService.ts
+++ b/src/Order/OrderService.ts
@@ -1,0 +1,51 @@
+import Pagination from "../Utility/Pagination.js";
+import { ordersDTO } from "./OrderDTO.js";
+import OrderRepository from "./OrderRepository.js";
+
+
+
+export default class OrderService extends Pagination {
+    constructor() {
+        super();
+    }
+
+    public async getAllOrders({ pageNum, pageSize, sortBy, sortDir, filterBy, searchValue }: OrderQueryType) {
+        const orderRepository = new OrderRepository();
+        this.calculateOffset(pageSize, pageNum);
+        const numericRegex: RegExp = /^[0-9]+$/;
+        
+        let orderResult: ResultPagination<any> = {};
+
+        if (searchValue && filterBy) {
+
+            if (numericRegex.test(searchValue)) {
+                const searchValueInt = parseInt(searchValue);
+                orderResult = await orderRepository.getAllItemsNumberAllPagination(pageSize, this.offset, sortBy, sortDir, searchValueInt, filterBy);
+            } else {
+                orderResult = await orderRepository.getAllItemsAllPagination(pageSize, this.offset, sortBy, sortDir, searchValue, filterBy);
+            }
+            
+            return ordersDTO(orderResult);
+        }
+
+        if (searchValue) {
+            
+            if (numericRegex.test(searchValue)) {
+                const searchValueInt = parseInt(searchValue)
+                orderResult = await orderRepository.getAllItemsSearchNumberPagination(pageSize, this.offset, sortBy, sortDir, searchValueInt);
+            } else {
+                orderResult = await orderRepository.getAllItemsSearchPagination(pageSize, this.offset, sortBy, sortDir, searchValue);
+            }
+
+            return ordersDTO(orderResult);
+        }
+
+        if (filterBy) {
+            orderResult = await orderRepository.getAllItemsFilterPagination(pageSize, this.offset, sortBy, sortDir, filterBy);
+            return ordersDTO(orderResult);
+        }
+
+        orderResult = await orderRepository.getAllItemsPagination(pageSize, this.offset, sortBy, sortDir);
+        return ordersDTO(orderResult);
+    }
+}

--- a/src/Order/OrderService.ts
+++ b/src/Order/OrderService.ts
@@ -115,10 +115,7 @@ export default class OrderService extends Pagination {
         // check status guard
         const orderStatus = await orderRepository.getOrderStatus(id);
 
-        if (
-            orderStatus.status === 'COMPLETED' ||
-            orderStatus.status === 'IN_PROGRESS'
-        ) {
+        if (orderStatus.status === "COMPLETED" || orderStatus.status === "IN_PROGRESS" || orderStatus.status === "CANCELED") {
             throw new Error(`Order is ${orderStatus.status.toLowerCase()}`);
         }
 

--- a/src/Order/OrderService.ts
+++ b/src/Order/OrderService.ts
@@ -1,20 +1,14 @@
-import Pagination from '../Utility/Pagination.js';
-import { orderDTO, ordersDTO } from './OrderDTO.js';
-import OrderRepository from './OrderRepository.js';
+import { Status, Task } from "@prisma/client";
+import Pagination from "../Utility/Pagination.js";
+import { orderDTO, ordersDTO } from "./OrderDTO.js";
+import OrderRepository from "./OrderRepository.js";
 
 export default class OrderService extends Pagination {
     constructor() {
         super();
     }
 
-    public async getAllOrders({
-        pageNum,
-        pageSize,
-        sortBy,
-        sortDir,
-        filterBy,
-        searchValue,
-    }: OrderQueryType) {
+    public async getAllOrders({ pageNum, pageSize, sortBy, sortDir, filterBy, searchValue }: OrderQueryType) {
         const orderRepository = new OrderRepository();
         this.calculateOffset(pageSize, pageNum);
         const numericRegex: RegExp = /^[0-9]+$/;
@@ -24,24 +18,9 @@ export default class OrderService extends Pagination {
         if (searchValue && filterBy) {
             if (numericRegex.test(searchValue)) {
                 const searchValueInt = parseInt(searchValue);
-                orderResult =
-                    await orderRepository.getAllItemsNumberAllPagination(
-                        pageSize,
-                        this.offset,
-                        sortBy,
-                        sortDir,
-                        searchValueInt,
-                        filterBy
-                    );
+                orderResult = await orderRepository.getAllItemsNumberAllPagination(pageSize, this.offset, sortBy, sortDir, searchValueInt, filterBy);
             } else {
-                orderResult = await orderRepository.getAllItemsAllPagination(
-                    pageSize,
-                    this.offset,
-                    sortBy,
-                    sortDir,
-                    searchValue,
-                    filterBy
-                );
+                orderResult = await orderRepository.getAllItemsAllPagination(pageSize, this.offset, sortBy, sortDir, searchValue, filterBy);
             }
 
             return ordersDTO(orderResult);
@@ -50,44 +29,20 @@ export default class OrderService extends Pagination {
         if (searchValue) {
             if (numericRegex.test(searchValue)) {
                 const searchValueInt = parseInt(searchValue);
-                orderResult =
-                    await orderRepository.getAllItemsSearchNumberPagination(
-                        pageSize,
-                        this.offset,
-                        sortBy,
-                        sortDir,
-                        searchValueInt
-                    );
+                orderResult = await orderRepository.getAllItemsSearchNumberPagination(pageSize, this.offset, sortBy, sortDir, searchValueInt);
             } else {
-                orderResult = await orderRepository.getAllItemsSearchPagination(
-                    pageSize,
-                    this.offset,
-                    sortBy,
-                    sortDir,
-                    searchValue
-                );
+                orderResult = await orderRepository.getAllItemsSearchPagination(pageSize, this.offset, sortBy, sortDir, searchValue);
             }
 
             return ordersDTO(orderResult);
         }
 
         if (filterBy) {
-            orderResult = await orderRepository.getAllItemsFilterPagination(
-                pageSize,
-                this.offset,
-                sortBy,
-                sortDir,
-                filterBy
-            );
+            orderResult = await orderRepository.getAllItemsFilterPagination(pageSize, this.offset, sortBy, sortDir, filterBy);
             return ordersDTO(orderResult);
         }
 
-        orderResult = await orderRepository.getAllItemsPagination(
-            pageSize,
-            this.offset,
-            sortBy,
-            sortDir
-        );
+        orderResult = await orderRepository.getAllItemsPagination(pageSize, this.offset, sortBy, sortDir);
         return ordersDTO(orderResult);
     }
 
@@ -95,5 +50,17 @@ export default class OrderService extends Pagination {
         const orderRepository = new OrderRepository();
         const result = await orderRepository.getSingleOrder(id);
         return orderDTO(result);
+    }
+
+    public async updateOrderStatus(id: number, status: Status) {
+        const orderRepository = new OrderRepository();
+
+        return orderRepository.updateOrderStatus(id, status);
+    }
+
+    public async updateOrderTasks(id: number, tasks: Task[]) {
+        const orderRepository = new OrderRepository();
+
+        return orderRepository.updateOrderTasks(id, tasks);
     }
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -4,6 +4,7 @@ import cors from 'cors';
 import { customerRouter } from './Customer/CustomerRouter.js';
 import carRouter from './Car/CarRouter.js';
 import { employeeRouter } from "./Employee/EmployeeRouter.js";
+import { orderRouter } from './Order/OrderRouter.js';
 
 
 export default function createServer() {
@@ -13,7 +14,7 @@ export default function createServer() {
     app.use(cors());
 
     //Routes her
-    app.use('/', customerRouter, carRouter, employeeRouter);
+    app.use('/', customerRouter, carRouter, employeeRouter, orderRouter);
     // Routes slut
 
     app.use('/', async (_req: Request, res: Response) => {

--- a/src/shared.types.d.ts
+++ b/src/shared.types.d.ts
@@ -1,7 +1,24 @@
 interface IPagination<T> {
-    getAllItemsPagination: (limit: number, offset: number, sortBy: string, sortDir: string) => Promise<ResultPagination<T>>;
-    getAllItemsSearchPagination: (limit: number, offset: number, sortBy: string, sortDir: string, searchValue: string) => Promise<ResultPagination<T>>;
-    getAllItemsFilterPagination?: (limit: number, offset: number, sortBy: string, sortDir: string, filterBy: string | Department | Status) => Promise<ResultPagination<T>>;
+    getAllItemsPagination: (
+        limit: number,
+        offset: number,
+        sortBy: string,
+        sortDir: string
+    ) => Promise<ResultPagination<T>>;
+    getAllItemsSearchPagination: (
+        limit: number,
+        offset: number,
+        sortBy: string,
+        sortDir: string,
+        searchValue: string
+    ) => Promise<ResultPagination<T>>;
+    getAllItemsFilterPagination?: (
+        limit: number,
+        offset: number,
+        sortBy: string,
+        sortDir: string,
+        filterBy: string | Department | Status
+    ) => Promise<ResultPagination<T>>;
     getAllItemsAllPagination?: (
         limit: number,
         offset: number,
@@ -63,8 +80,8 @@ type EmployeeQueryType = QueryType & {
 };
 
 type OrderQueryType = QueryType & {
-    filterBy: Status
-}
+    filterBy: Status;
+};
 
 //Service slut
 
@@ -98,3 +115,95 @@ type NewCar = {
 };
 
 type OrderResult = Order & Car;
+
+type SingleOrder = {
+    id: number;
+    status: Status;
+    orderStartDate: Date;
+    createdAt: Date;
+    updatedAt: Date;
+    car: {
+        id: number;
+        registrationNumber: string;
+        vinNumber: string;
+        brand: string;
+        model: string;
+        modelVariant: string;
+        mileage: number;
+    };
+    customer: {
+        id: string;
+        firstName: string;
+        lastName: string;
+        email: string;
+        phone: number;
+    };
+    taskInstances: {
+        id: number;
+        status: Status;
+        updatedAt: Date;
+        employee: {
+            firstName: string;
+            lastName: string;
+            department: Department;
+        } | null;
+        task: {
+            name: string;
+            description: string;
+        };
+        subtaskInstances: {
+            id: number;
+            status: Status;
+            updatedAt: Date;
+            subtask: {
+                name: string;
+                time: number;
+                description: string;
+            };
+        }[];
+    }[];
+};
+
+type SingleOrderDTO = {
+    id: number;
+    status: Status;
+    orderStartDate: Date;
+    createdAt: Date;
+    updatedAt: Date;
+    car: {
+        id: number;
+        registrationNumber: string;
+        vinNumber: string;
+        brand: string;
+        model: string;
+        modelVariant: string;
+        mileage: number;
+    };
+    customer: {
+        id: string;
+        firstName: string;
+        lastName: string;
+        email: string;
+        phone: number;
+    };
+    tasks: {
+        id: number;
+        status: Status;
+        updatedAt: Date;
+        name: string;
+        description: string;
+        employee: {
+            firstName: string | undefined;
+            lastName: string | undefined;
+            department: Department;
+        } | null;
+        subtasks: {
+            id: number;
+            status: Status;
+            name: string;
+            time: number;
+            description: string;
+            updatedAt: Date;
+        }[];
+    }[];
+};

--- a/src/shared.types.d.ts
+++ b/src/shared.types.d.ts
@@ -1,26 +1,30 @@
-
-
 interface IPagination<T> {
     getAllItemsPagination: (limit: number, offset: number, sortBy: string, sortDir: string) => Promise<ResultPagination<T>>;
     getAllItemsSearchPagination: (limit: number, offset: number, sortBy: string, sortDir: string, searchValue: string) => Promise<ResultPagination<T>>;
-    getAllItemsFilterPagination?: (limit: number, offset: number, sortBy: string, sortDir: string, filterBy: string | Department) => Promise<ResultPagination<T>>;
-    getAllItemsAllPagination?: (limit: number, offset: number, sortBy: string, sortDir: string, searchValue: string, filterBy: string | Department) => Promise<ResultPagination<T>>;
+    getAllItemsFilterPagination?: (limit: number, offset: number, sortBy: string, sortDir: string, filterBy: string | Department | Status) => Promise<ResultPagination<T>>;
+    getAllItemsAllPagination?: (
+        limit: number,
+        offset: number,
+        sortBy: string,
+        sortDir: string,
+        searchValue: string,
+        filterBy: string | Department | Status
+    ) => Promise<ResultPagination<T>>;
 }
 
 //Controller
 type ReqQuery = {
-    sortDir: string,
-    sortBy: string,
-    pageNum: string,
-    pageSize: string,
-    searchValue?: string,
-    filterBy?: string
-}
+    sortDir: string;
+    sortBy: string;
+    pageNum: string;
+    pageSize: string;
+    searchValue?: string;
+    filterBy?: string;
+};
 
 type ReqParams = {
-    id: string
-}
-
+    id: string;
+};
 
 type EmployeeReqBody = {
     id: string;
@@ -41,52 +45,56 @@ type CustomerReqBody = {
     email: string;
 };
 
-
-
 //Controller slut
 
 //Service
 
 type QueryType = {
-    sortDir: string,
-    sortBy: string,
-    pageNum: number,
-    pageSize: number,
-    searchValue?: string,
-    filterBy?: string
-}
+    sortDir: string;
+    sortBy: string;
+    pageNum: number;
+    pageSize: number;
+    searchValue?: string;
+    filterBy?: string;
+};
 
 type EmployeeQueryType = QueryType & {
-    filterBy: Department
+    filterBy: Department;
+};
+
+type OrderQueryType = QueryType & {
+    filterBy: Status
 }
 
 //Service slut
 
 //Repository
 type MetaData = {
-    limit: number,
-    offset: number,
-    totalCount: number
-}
+    limit: number;
+    offset: number;
+    totalCount: number;
+};
 
 type ResultPagination<T> = {
-    data?: T[],
-    metaData?: MetaData
-}
+    data?: T[];
+    metaData?: MetaData;
+};
 
 //Repository slut
 
 // Car
 type NewCar = {
-    registrationNumber: string,
-    vinNumber: string,
-    model: string,
-    brand: string,
-    modelVariant: string,
-    customerId: string,
-    firstRegistration: string | Date,
-    mileage: number,
-    lastInspectionDate: string | Date,
-    lastInspectionKind: string,
-    lastInspectionResult: string
-}
+    registrationNumber: string;
+    vinNumber: string;
+    model: string;
+    brand: string;
+    modelVariant: string;
+    customerId: string;
+    firstRegistration: string | Date;
+    mileage: number;
+    lastInspectionDate: string | Date;
+    lastInspectionKind: string;
+    lastInspectionResult: string;
+};
+
+type OrderResult = Order & Car;

--- a/src/shared.types.d.ts
+++ b/src/shared.types.d.ts
@@ -77,7 +77,7 @@ type ResultPagination<T> = {
 //Repository slut
 
 // Car
-interface NewCar {
+type NewCar = {
     registrationNumber: string,
     vinNumber: string,
     model: string,
@@ -89,8 +89,4 @@ interface NewCar {
     lastInspectionDate: string | Date,
     lastInspectionKind: string,
     lastInspectionResult: string
-}
-
-interface UpdatedCar extends NewCar {
-    id: number
 }

--- a/src/shared.types.d.ts
+++ b/src/shared.types.d.ts
@@ -114,6 +114,15 @@ type NewCar = {
     lastInspectionResult: string;
 };
 
+// Order
+type NewOrder = {
+    status?: Status;
+    orderStartDate: string | Date;
+    carId: number;
+    customerId: string;
+    tasks: Task[];
+};
+
 type OrderResult = Order & Car;
 
 type SingleOrder = {


### PR DESCRIPTION
getAll og getSingle blev lavet sammen, så der er ikke noget nyt.
der er tilføjet guards til updateOrderStatus og updateOrderTasks i servicelaget.

logisk omstrukturering af updateOrderTasks således at den ikke længere bare sletter samtlige tasks og subtasks, men i stedet holder tasks fra request op imod de tasks der allerede er på ordren, og tilføjer/sletter efter behov.

createOrder er lavet med meget af den samme logik på repositorylaget som updateOrderTasks - der bør være mulighed for at refactor disse med DRY for øje.